### PR TITLE
fix internal orm, use current cursor

### DIFF
--- a/utilities_collection/orm.py
+++ b/utilities_collection/orm.py
@@ -26,21 +26,7 @@ def create_cursor(cursor: odoo.sql_db.Cursor) -> psycopg2.extensions.cursor:
     @return:
         cursor (psycopg2.extensions.cursor)
     """
-    cursor_info = cursor._cnx._original_dsn
-    db_host = cursor_info.get('host')
-    db_port = cursor_info.get('port')
-    db_user = cursor_info.get('user')
-    db_name = cursor_info.get('database')
-    db_password = cursor_info.get('password')
-
-    try:
-        conn = psycopg2.connect(
-            user=db_user, host=db_host, port=db_port, password=db_password,
-            dbname=db_name
-        )
-        return conn.cursor()
-    except psycopg2.OperationalError as err:
-        raise Warning('Could not create cursor: ' + str(err))
+    return cursor
 
 
 def commit_cursor(cursor: psycopg2.extensions.cursor):


### PR DESCRIPTION
# Descripcion
Debido a cambios base en el repo de odoo se vio afectado el modulo de nomina, la comunidad de odoo elimino un atributo que permitía crear nuevas conexiones a la base de datos rápidas y temporales para ejecutar consultas, por lo tanto se tuvo que reutilizar el cursor por defecto del framework, en consecuencia se va a ver afectado el rendimiento para las operaciones masivas. 

Para mas información de los cambios realizados por la comunidad de odoo ver el [commit](https://github.com/odoo/odoo/commit/bf555bf68224283c3f892b198d1022c7b85243d8#diff-c1b121d95925eb4034fdeb0adc4ab9f045e28c1033789bfbe08f7cf3c8c53478L691)

![Captura de pantalla de 2023-04-14 11-02-45](https://user-images.githubusercontent.com/109321974/232106570-e45dc0e8-f11a-46ac-be62-d6c95356eb78.png)
